### PR TITLE
Add pages_user_agent_credhub_client

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -401,6 +401,12 @@ instance_groups:
             authorities: credhub.read, credhub.write
             scope: uaa.none,credhub.read,credhub.write
             secret: ((pgp_credhub_client_secret))
+          pages_user_agent_credhub_client:
+            override: true
+            authorized-grant-types: client_credentials,refresh_token
+            authorities: credhub.read, credhub.write
+            scope: uaa.none,credhub.read,credhub.write
+            secret: ((pages_user_agent_credhub_client_secret))            
           opensearch_proxy_ci_client:
             override: true
             authorized-grant-types: client_credentials,refresh_token
@@ -544,6 +550,8 @@ variables:
 - name: doomsday_readonly_secret_staging
   type: password
 - name: pgp_credhub_client_secret
+  type: password
+- name: pages_user_agent_credhub_client_secret
   type: password
 - name: opensearch_proxy_ci_client_secret
   type: password


### PR DESCRIPTION
## Changes proposed in this pull request:
- Needed for new dedicated credhub client to retrieve waf slot variables
- Part of https://github.com/cloud-gov/private/issues/1966
-

## security considerations
Secret is generated and stored in tooling bosh credhub.
