### PR TITLE
add credhub client for Opensearch CI

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -421,6 +421,12 @@ instance_groups:
             authorities: credhub.read, credhub.write
             scope: uaa.none,credhub.read,credhub.write
             secret: ((opensearch_proxy_ci_client_secret))
+          opensearch_ci_client:
+            override: true
+            authorized-grant-types: client_credentials,refresh_token
+            authorities: credhub.read, credhub.write
+            scope: uaa.none,credhub.read,credhub.write
+            secret: ((opensearch_ci_client_secret))            
 
           # Defect Dojo auth
           defectdojo_staging:
@@ -570,6 +576,8 @@ variables:
   type: password
 - name: opensearch_proxy_ci_client_secret
   type: password
+- name: opensearch_ci_client_secret
+  type: password  
 - name: concourse_client_secret_staging
   type: password
 - name: concourse_client_secret_production


### PR DESCRIPTION
## Changes proposed in this pull request:

- add credhub client for Opensearch CI to allow updating credhub credentials, which will be used to keep test user passwords from expiring

## security considerations

Client will be used to set credentials containing user passwords from within a pipeline so that passwords for test users do not expire