### PR TITLE
Add zap scan client

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -437,6 +437,14 @@ instance_groups:
                 scope: uaa.none,credhub.read,credhub.write
                 secret: ((opensearch_ci_client_secret))
 
+              #zap scan client - just enough permissions to use the zap-scan-user to login and create a token via "uaac context"
+              zap_scan_client:
+                override: true
+                authorized-grant-types: password,refresh_token
+                authorities: uaa.user
+                scope: uaa.user
+                secret: ((zap_scan_client_secret))
+
               # Defect Dojo auth
               defectdojo_development:
                 <<: *client-template
@@ -634,6 +642,8 @@ variables:
   - name: doomsday_client_secret_production
     type: password
   - name: nessus_client_secret_production
+    type: password
+  - name: zap_scan_client_secret
     type: password
   - name: doomsday_client_secret_east
     type: password


### PR DESCRIPTION
## Changes proposed in this pull request:
- Tried to use the `admin` client along with the uaac CLI to auth using the zap-scan-user.  To use the `uaac token owner get` you need a client, client secret, user and user password.
- The client needs to have the scope & authority of `uaa.user` in order to login on behalf of the user account.  The `admin` client, while an admin, still only has a scope of `uaa.none`, so a new client dedicated client is being created.
- Part of https://github.com/cloud-gov/deploy-cf/issues/988

## security considerations
New client secret stashed in Credhub and client only has enough permissions to shepherd the user login for token generation.
